### PR TITLE
Fix editorial layout and strengthen recruiter profile

### DIFF
--- a/_layouts/editorial.html
+++ b/_layouts/editorial.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ '/css/landing.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/css/landing.css' | relative_url }}?v=20260816-3">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ '/images/icons/png/icon-32x32.png' | relative_url }}">
   </head>
   <body>

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ '/css/landing.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/css/landing.css' | relative_url }}?v=20260816-3">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ '/images/icons/png/icon-32x32.png' | relative_url }}">
     <script type="application/ld+json">
       {

--- a/css/landing.css
+++ b/css/landing.css
@@ -43,7 +43,7 @@ button, a { -webkit-tap-highlight-color: transparent; }
 }
 .wordmark { display: inline-flex; align-items: baseline; gap: 9px; text-decoration: none; }
 .wordmark span { font: 400 36px/1 "DM Serif Display", Georgia, serif; letter-spacing: -.5px; }
-.wordmark small { color: var(--blue); font-size: 10px; font-weight: 800; letter-spacing: .15em; text-transform: uppercase; }
+.wordmark small { padding: 3px 6px 2px; border: 1px solid rgba(7,88,217,.28); border-radius: 999px; color: var(--blue); font-size: 9px; font-weight: 800; line-height: 1; letter-spacing: .12em; text-transform: uppercase; }
 .site-nav { display: flex; align-items: center; gap: clamp(26px, 3.5vw, 58px); }
 .site-nav a { font-weight: 500; text-decoration: none; padding-block: 8px; position: relative; }
 .site-nav a:not(.language-switch)::after { content: ""; position: absolute; left: 0; right: 100%; bottom: 3px; height: 1px; background: var(--blue); transition: right .2s ease; }
@@ -149,6 +149,8 @@ h1 { max-width: 740px; margin: 0; font-size: clamp(54px, 5vw, 78px); line-height
 .editorial-content ul { padding-left: 23px; }
 .editorial-content li { margin-bottom: 9px; }
 .editorial-lead { max-width: 780px; color: var(--muted); font-size: 22px; line-height: 1.6; }
+.profile-actions { margin: 34px 0 42px; display: flex; flex-wrap: wrap; align-items: center; gap: 14px; }
+.profile-actions .button { min-height: 50px; }
 .profile-facts { margin: 42px 0; display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid var(--line); }
 .profile-facts div { padding: 26px; }
 .profile-facts div + div { border-left: 1px solid var(--line); }
@@ -156,6 +158,21 @@ h1 { max-width: 740px; margin: 0; font-size: clamp(54px, 5vw, 78px); line-height
 .profile-facts span { color: var(--ink); font-family: "DM Serif Display", Georgia, serif; font-size: 23px; line-height: 1.25; }
 .editorial-callout { margin-top: 56px; padding: 34px; border-left: 3px solid var(--blue); background: var(--soft); }
 .editorial-callout h2 { margin-top: 0; }
+.case-grid { margin: 34px 0 18px; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); border: 1px solid var(--line); }
+.case-grid article { min-height: 255px; padding: 30px; }
+.case-grid article:nth-child(even) { border-left: 1px solid var(--line); }
+.case-grid article:nth-child(n+3) { border-top: 1px solid var(--line); }
+.case-grid h3 { margin: 8px 0 13px; font: 400 28px/1.12 "DM Serif Display", Georgia, serif; }
+.case-grid article > p:last-child { margin: 0; color: var(--muted); font-size: 16px; line-height: 1.6; }
+.case-kicker { margin: 0 !important; color: var(--blue) !important; font-size: 12px !important; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+.skill-cloud { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 10px; }
+.skill-cloud span { padding: 8px 13px; border: 1px solid var(--line); border-radius: 999px; background: white; color: #243044; font-size: 14px; line-height: 1.2; }
+.recruiter-callout { padding: 44px; border-left: 0; background: var(--ink); color: white; }
+.recruiter-callout h2 { max-width: 700px; color: white; }
+.recruiter-callout > p:not(.case-kicker) { max-width: 760px; color: #cbd5e1; }
+.recruiter-callout .case-kicker { color: #76a9ff !important; }
+.recruiter-callout .profile-actions { margin-bottom: 0; }
+.recruiter-callout .text-link { color: white; }
 
 .archive-toolbar { display: grid; grid-template-columns: 1fr auto; align-items: end; gap: 8px 24px; margin-bottom: 38px; }
 .archive-toolbar label { color: var(--ink); font-weight: 700; }
@@ -166,6 +183,7 @@ h1 { max-width: 740px; margin: 0; font-size: clamp(54px, 5vw, 78px); line-height
 .archive-search-wrap input { width: 100%; height: 52px; border: 0; outline: 0; background: transparent; color: var(--ink); font: inherit; }
 .archive-list { border-top: 1px solid var(--line); }
 .archive-entry { display: grid; grid-template-columns: 120px 1fr 30px; gap: 24px; align-items: center; padding: 24px 0; border-bottom: 1px solid var(--line); }
+.archive-entry[hidden] { display: none; }
 .archive-entry time { color: var(--muted); font-size: 14px; }
 .archive-entry h2 { margin: 0; font: 400 27px/1.2 "DM Serif Display", Georgia, serif; }
 .archive-entry h2 a { color: var(--ink); text-decoration: none; }
@@ -226,6 +244,13 @@ h1 { max-width: 740px; margin: 0; font-size: clamp(54px, 5vw, 78px); line-height
   .editorial-content h2 { margin-top: 48px; font-size: 34px; }
   .profile-facts { grid-template-columns: 1fr; }
   .profile-facts div + div { border-left: 0; border-top: 1px solid var(--line); }
+  .profile-actions { align-items: stretch; flex-direction: column; }
+  .profile-actions .button { width: 100%; }
+  .case-grid { grid-template-columns: 1fr; }
+  .case-grid article { min-height: auto; padding: 26px; }
+  .case-grid article:nth-child(even) { border-left: 0; }
+  .case-grid article + article { border-top: 1px solid var(--line); }
+  .recruiter-callout { padding: 32px 25px; }
   .archive-toolbar { grid-template-columns: 1fr; }
   .archive-toolbar > p { grid-column: 1; grid-row: auto; }
   .archive-entry { grid-template-columns: 1fr 26px; gap: 8px 14px; padding: 22px 0; }

--- a/pages/2017-01-02-dr-suat-atan-kimdir.md
+++ b/pages/2017-01-02-dr-suat-atan-kimdir.md
@@ -1,41 +1,82 @@
 ---
 layout: editorial
-title: Dr. Suat Atan Kimdir?
-description: Kurumsal yapay zekâ, RAG, NLP ve veri sistemleri alanlarında çalışan veri bilimci, danışman, araştırmacı, eğitmen ve yazar.
+title: Dr. Suat Atan — Kıdemli Veri Bilimci ve Uygulamalı AI Lideri
+description: RAG, NLP, makine öğrenmesi ve veri platformlarını üretime taşıyan; düzenlemeye tabi sektörler ve uluslararası kuruluşlarda 15+ yıllık deneyime sahip veri bilimci ve yapay zekâ lideri.
 permalink: /pages/2017-01-02-dr-suat-atan-kimdir.html
 lang: tr
-eyebrow: MÜHENDİS · VERİ BİLİMCİ · EĞİTMEN
+eyebrow: PROFESYONEL PROFİL · KIDEMLİ VE LİDER POZİSYONLAR
 ---
 
-<p class="editorial-lead">Teknik derinliği, kurumların gerçek ihtiyaçlarını ve ölçülebilir sonuçları bir araya getirerek kullanışlı yapay zekâ ve veri sistemleri geliştiriyorum.</p>
+<p class="editorial-lead">Belirsiz iş problemlerini üretimde çalışan yapay zekâ ve veri sistemlerine dönüştürüyorum. Kurumsal RAG, NLP, tahminleme, veri platformları ve ajan tabanlı iş akışlarında güvenilirlik, benimsenme ve ölçülebilir değer odağıyla çalışıyorum.</p>
 
-<div class="profile-facts">
-  <div><strong>Akademik</strong><span>Doktora ve NLP postdoktora araştırması</span></div>
-  <div><strong>Deneyim</strong><span>Kamu ve düzenlemeye tabi sektörlerde 15+ yıl</span></div>
-  <div><strong>Danışmanlık</strong><span>Ontario Cloud üzerinden kurumsal çözümler</span></div>
+<div class="profile-actions">
+  <a class="button button-primary" href="mailto:suatatan+site@gmail.com?subject=Kariyer%20fırsatı">İletişime geçin</a>
+  <a class="button button-secondary" href="https://www.linkedin.com/in/suatatan" target="_blank" rel="me noopener">LinkedIn profili</a>
 </div>
 
-## Ne yapıyorum?
+<div class="profile-facts">
+  <div><strong>Deneyim</strong><span>AI, veri ve kurumsal yazılımda 15+ yıl</span></div>
+  <div><strong>Araştırma</strong><span>Metin madenciliği doktorası · İtalya’da NLP postdoktorası</span></div>
+  <div><strong>Çalışma modeli</strong><span>Ankara merkezli · Kuzey Amerika ve Avrupa’ya uzaktan</span></div>
+</div>
 
-Bugünkü çalışmalarım kurumsal RAG sistemleri, semantik arama, belge zekâsı, tahminleme, yapay zekâ ajanları ve üretken yapay zekânın sorumlu biçimde kurumsal süreçlere alınması üzerine yoğunlaşıyor. Kamu kurumları, bankalar, enerji şirketleri, üniversiteler ve uluslararası kuruluşlar için fikir aşamasından üretime kadar veri, yapay zekâ ve yazılım projeleri geliştirdim.
+## Güncel çalışmalarım
 
-Tarım ve Kırsal Kalkınmayı Destekleme Kurumunda kurumsal yapay zekâ ve veri çalışmalarına katkı sağlıyor; gıda kaybı ve israfının ölçülmesine yönelik uluslararası çalışmalarda kıdemli uzman olarak görev alıyorum. Kurucusu olduğum [Ontario Bilişim ve Danışmanlık Ltd. Şti.](https://ontariocloud.com) üzerinden kurumlara yapay zekâ, NLP ve veri mühendisliği danışmanlığı ile uygulamalı eğitimler sunuyorum.
+[Ontario Bilişim ve Danışmanlık Ltd. Şti.](https://ontariocloud.com) üzerinden uygulamalı yapay zekâ, NLP, veri mühendisliği ve tahminleme projelerine liderlik ediyorum. Tarım ve Kırsal Kalkınmayı Destekleme Kurumunda kurumsal yapay zekâ ve yazılım çalışmalarına katkı sağlıyor; gıda kaybı ve israfının ölçülmesine yönelik uluslararası programlarda kıdemli uzman olarak görev alıyorum.
 
-## Akademik ve mesleki geçmiş
+Yakın dönem çalışmalarım; kurumsal bilgi sistemleri kurmayı, yapay zekâ destekli iş akışları tasarlamayı, çok disiplinli teknik ekipleri yönetmeyi ve veri bilimi ekiplerinin üretken yapay zekâ kavramlarından üretime hazır uygulamalara geçmesini sağlamayı kapsıyor.
 
-Temel eğitimim inşaat mühendisliği alanında. Ardından MBA yaptım; metin madenciliği ve duygu analizi odaklı doktoramı tamamladım. İtalya’daki Torino Üniversitesinde doğal dil işleme alanında postdoktora araştırmaları yürüttüm. Mühendislik, işletme, yazılım geliştirme ve uygulamalı araştırmayı birleştiren bu geçmiş, çalışma biçimimi de belirliyor: önce gerçek kararı veya iş akışını anlamak, sonra en sade ve güvenilir mimariyi kurmak ve sonucun pratikte işe yarayıp yaramadığını ölçmek.
+## Yakın dönemden seçili etkiler
 
-Yüksek lisans düzeyinde ağ analizi dersi verdim; Python, R, Google App Engine ve ağ analizi konularında kitaplar yazdım ve editörlük yaptım. [Udemy eğitimlerimde](https://www.udemy.com/user/suat-atan/) aynı birikimi anlaşılır ve uygulanabilir öğrenme deneyimlerine dönüştürüyorum.
+<div class="case-grid">
+  <article>
+    <p class="case-kicker">Kurumsal RAG</p>
+    <h3>Mevzuat bilgi asistanı</h3>
+    <p>Bosphorus AI bünyesinde 10 kişilik ekibe liderlik ederek Emeklilik Gözetim Merkezi için mevzuat odaklı bir RAG asistanı geliştirdim.</p>
+  </article>
+  <article>
+    <p class="case-kicker">AI Yetkinliği</p>
+    <h3>Gemini ve RAG eğitimi</h3>
+    <p>ING Türkiye’nin 30 kişilik veri bilimi ekibine Gemini AI, RAG mimarisi ve uygulama geliştirme üzerine senaryo temelli eğitim verdim.</p>
+  </article>
+  <article>
+    <p class="case-kicker">Uluslararası Veri</p>
+    <h3>Gıda kaybı ve israfı zekâsı</h3>
+    <p>53 ülke, 87 ürün türü ve 56.376 ülke-yıl-ürün birleşimini kapsayan IOFS programının; dijital platform ve AI ajanıyla birlikte geliştirilmesine katkı sundum.</p>
+  </article>
+  <article>
+    <p class="case-kicker">Tahminleme</p>
+    <h3>Enerji karar sistemleri</h3>
+    <p>Aras, Başkent ve Dicle elektrik dağıtım kuruluşları için tahminleme ve veri çözümleri geliştiriyorum.</p>
+  </article>
+</div>
 
-## Danışmanlık dışındaki çalışmalar
+## Sektörler arasında taşınan deneyim
 
-[FYLARK](https://fylark.com), başta disleksili gençler olmak üzere farklı öğrenen çocuklar için geliştirdiğim erişilebilir teknoloji eğitimi girişimidir. Çocukların kodlama ve yapay zekâyı küçük, görsel ve güven veren adımlarla keşfetmesini amaçlar.
+2022’den Ocak 2026’ya kadar Kanada merkezli [VectorSolv](https://vectorsolv.com) ile önce çalışan, ardından danışman olarak Kuzey Amerika otomotiv garanti ve sigorta operasyonlarına yönelik veri hatları, analitik sistemler ve NLP/LLM iş akışları geliştirdim. Bu çalışmalar Azure, SQL, API’ler, Git/Docker süreçleri ve dağıtık iş ekiplerinin kullandığı üretim sistemlerini kapsıyordu.
 
-Bu siteyi 2006’dan beri açık bir bellek olarak tutuyorum: teknik notların, araştırmaların, gözlemlerin ve kaybolmaması gereken fikirlerin bulunduğu bir alan. [Verimlilik Bülteni](https://suatatan.substack.com)’nde yapay zekâ, öğrenme ve anlamlı çalışma üzerine Türkçe; [3000 Days](https://3000days.substack.com)’te ise meditasyon, dikkat ve iç yaşam üzerine İngilizce yazıyorum.
+Önceki ve eş zamanlı çalışmalarım bankacılık, enerji, üniversiteler, kamu kurumları ve uluslararası kuruluşlara uzanıyor. Kadir Has Üniversitesi için nefret söylemi odaklı web scraping ve metin analitiği, düzenlemeye tabi kurumlar için kurumsal AI çözümleri ve operasyon ekipleri için karar destek sistemleri bunlardan bazıları.
 
-<div class="editorial-callout">
-  <h2>Birlikte çalışalım</h2>
-  <p>Danışmanlık, eğitim, araştırma iş birliği veya konuşma talepleri için <a href="mailto:suatatan+site@gmail.com">suatatan+site@gmail.com</a> adresinden ulaşabilir ya da <a href="https://ontariocloud.com">Ontario Cloud</a> sitesini ziyaret edebilirsiniz.</p>
+## Teknik odağım
+
+<div class="skill-cloud">
+  <span>Python</span><span>SQL</span><span>R</span><span>RAG ve LLM uygulamaları</span><span>Ajan tabanlı iş akışları</span><span>NLP</span><span>Makine öğrenmesi</span><span>Tahminleme</span><span>Semantik arama</span><span>Bilgi çıkarımı</span><span>Azure ve AWS</span><span>Databricks ve Spark</span><span>PostgreSQL · MSSQL · MongoDB</span><span>Docker ve CI/CD</span><span>Power BI ve Streamlit</span>
+</div>
+
+## Eğitim, öğretim ve kamusal çalışmalar
+
+Temel eğitimim inşaat mühendisliği alanında. Ardından MBA ve metin madenciliği odaklı mühendislik doktorası yaptım; Torino Üniversitesinde NLP alanında postdoktora araştırmaları yürüttüm. Yüksek lisans düzeyinde ağ analizi dersi verdim; Python, R, Google App Engine ve ağ analizi üzerine kitaplar yazdım ve editörlük yaptım.
+
+Disleksili gençlere yönelik erişilebilir kodlama ve yapay zekâ girişimi [FYLARK](https://fylark.com)’ı geliştirdim. [Verimlilik Bülteni](https://suatatan.substack.com)’nde Türkçe, [3000 Days](https://3000days.substack.com)’te İngilizce yazıyorum.
+
+<div class="editorial-callout recruiter-callout">
+  <p class="case-kicker">İŞE ALIM EKİPLERİ İÇİN</p>
+  <h2>Kıdemli veri bilimci veya uygulamalı AI lideri mi arıyorsunuz?</h2>
+  <p>Teknik liderliği üretim deneyimiyle birleştiren kıdemli veri bilimi, makine öğrenmesi, uygulamalı yapay zekâ ve AI platform rollerini görüşmeye açığım.</p>
+  <div class="profile-actions">
+    <a class="button button-primary" href="mailto:suatatan+site@gmail.com?subject=Kıdemli%20AI%20veya%20veri%20rolü">Suat’a yazın</a>
+    <a class="text-link" href="https://github.com/suatatan" target="_blank" rel="noopener">GitHub’ı inceleyin</a>
+  </div>
 </div>
 
 [English version](/pages/about-en.html)

--- a/pages/about-en.md
+++ b/pages/about-en.md
@@ -1,41 +1,82 @@
 ---
 layout: editorial
-title: About Dr. Suat Atan
-description: Data scientist, AI consultant, researcher, educator and writer working across enterprise AI, RAG, NLP and data systems.
+title: Dr. Suat Atan — Senior Data Scientist & Applied AI Leader
+description: Senior data scientist and AI leader with 15+ years of experience delivering RAG, NLP, machine-learning and data-platform solutions across regulated industries and international organizations.
 permalink: /pages/about-en.html
 lang: en
-eyebrow: ENGINEER · DATA SCIENTIST · EDUCATOR
+eyebrow: PROFESSIONAL PROFILE · OPEN TO SENIOR & LEAD ROLES
 ---
 
-<p class="editorial-lead">I build useful artificial-intelligence and data systems at the intersection of technical depth, organizational reality and measurable delivery.</p>
+<p class="editorial-lead">I turn ambiguous business problems into deployable AI and data systems. My work spans enterprise RAG, NLP, forecasting, data platforms and agentic workflows—with a consistent focus on reliability, adoption and measurable value.</p>
 
-<div class="profile-facts">
-  <div><strong>Academic</strong><span>PhD and NLP postdoctoral research</span></div>
-  <div><strong>Practice</strong><span>15+ years across public and regulated sectors</span></div>
-  <div><strong>Delivery</strong><span>AI consulting through Ontario Cloud</span></div>
+<div class="profile-actions">
+  <a class="button button-primary" href="mailto:suatatan+site@gmail.com?subject=Career%20opportunity">Contact me</a>
+  <a class="button button-secondary" href="https://www.linkedin.com/in/suatatan" target="_blank" rel="me noopener">LinkedIn profile</a>
 </div>
 
-## What I do
+<div class="profile-facts">
+  <div><strong>Experience</strong><span>15+ years in AI, data and enterprise software</span></div>
+  <div><strong>Research</strong><span>PhD in text mining · NLP postdoc in Italy</span></div>
+  <div><strong>Availability</strong><span>Ankara-based · Remote North America & Europe</span></div>
+</div>
 
-My current work centres on enterprise RAG systems, semantic search, document intelligence, forecasting, AI agents and the responsible adoption of generative AI. I have designed and delivered data and software initiatives for public institutions, banks, energy companies, universities and international organizations—from early discovery to production.
+## Current work
 
-I also work on institutional AI and data initiatives at Turkey’s Agriculture and Rural Development Support Institution and contribute as a senior expert to international work on food-loss and waste measurement. Through [Ontario Bilişim ve Danışmanlık Ltd. Şti.](https://ontariocloud.com), I provide consulting and practical training for organizations that need to turn AI ideas into reliable systems.
+I lead applied AI, NLP, data-engineering and forecasting engagements through [Ontario Bilişim ve Danışmanlık Ltd. Şti.](https://ontariocloud.com). I also contribute to institutional AI and software initiatives at Turkey’s Agriculture and Rural Development Support Institution and work as a senior expert on international food-loss and waste measurement programs.
 
-## Background
+My recent work includes building enterprise knowledge systems, designing AI-assisted organizational workflows, leading multidisciplinary technical teams and helping data-science groups move from generative-AI concepts to production-ready applications.
 
-My original training is in civil engineering. I later completed an MBA and a PhD focused on text mining and sentiment analysis, followed by postdoctoral research in natural language processing at the University of Turin. This combination of engineering, business, software development and applied research still shapes how I approach problems: begin with the real decision or workflow, choose the simplest dependable architecture, and test whether the result is genuinely useful.
+## Selected recent impact
 
-I have taught graduate-level network analysis and authored or edited books on Python, R, Google App Engine and network analysis. My [Udemy courses](https://www.udemy.com/user/suat-atan/) translate the same experience into accessible, practical learning.
+<div class="case-grid">
+  <article>
+    <p class="case-kicker">Enterprise RAG</p>
+    <h3>Regulatory knowledge assistant</h3>
+    <p>Led a 10-person Bosphorus AI team delivering a regulation-focused RAG assistant for Türkiye’s Pension Monitoring Center.</p>
+  </article>
+  <article>
+    <p class="case-kicker">AI Enablement</p>
+    <h3>Gemini and RAG training</h3>
+    <p>Trained ING Türkiye’s 30-person data-science team through hands-on scenarios covering Gemini AI, RAG architecture and application delivery.</p>
+  </article>
+  <article>
+    <p class="case-kicker">International Data</p>
+    <h3>Food loss and waste intelligence</h3>
+    <p>Co-developed an IOFS program spanning 53 countries, 87 product types and 56,376 country-year-product combinations, alongside a digital platform and AI agent.</p>
+  </article>
+  <article>
+    <p class="case-kicker">Forecasting</p>
+    <h3>Energy decision systems</h3>
+    <p>Developing forecasting and data solutions for Aras, Başkent and Dicle electricity-distribution organizations.</p>
+  </article>
+</div>
 
-## Projects beyond consulting
+## Experience that travels across industries
 
-[FYLARK](https://fylark.com) is an accessible technology-learning initiative for differently learning children, particularly young people with dyslexia. It uses visual, small-step learning experiences to help children explore coding and artificial intelligence with confidence.
+From 2022 to January 2026, I worked with Canada-based [VectorSolv](https://vectorsolv.com) as an employee and later as a contractor, delivering data pipelines, analytics and NLP/LLM workflows for North American automotive warranty and insurance operations. The work involved Azure, SQL, APIs, Git/Docker practices and production systems used by distributed business teams.
 
-I have maintained this website since 2006 as an open memory: technical notes, research, observations and ideas that deserve to remain findable. I publish two newsletters: [Verimlilik Bülteni](https://suatatan.substack.com) in Turkish, on artificial intelligence, learning and meaningful work; and [3000 Days](https://3000days.substack.com) in English, on meditation, attention and the inner life.
+Earlier and parallel engagements have covered banking, energy, universities, public institutions and international organizations. Examples include hate-speech web scraping and text analytics for Kadir Has University, enterprise AI work for regulated institutions, and decision-support systems for operational teams.
 
-<div class="editorial-callout">
-  <h2>Work with me</h2>
-  <p>For consulting, training, research collaboration or speaking enquiries, email <a href="mailto:suatatan+site@gmail.com">suatatan+site@gmail.com</a> or visit <a href="https://ontariocloud.com">Ontario Cloud</a>.</p>
+## Technical focus
+
+<div class="skill-cloud">
+  <span>Python</span><span>SQL</span><span>R</span><span>RAG & LLM applications</span><span>Agentic workflows</span><span>NLP</span><span>Machine learning</span><span>Forecasting</span><span>Semantic search</span><span>Information extraction</span><span>Azure & AWS</span><span>Databricks & Spark</span><span>PostgreSQL · MSSQL · MongoDB</span><span>Docker & CI/CD</span><span>Power BI & Streamlit</span>
+</div>
+
+## Education, teaching and public work
+
+My original training is in civil engineering. I later completed an MBA and a PhD in Engineering focused on text mining, followed by postdoctoral NLP research at the University of Turin. I have taught network analysis at graduate level and authored or edited books on Python, R, Google App Engine and network analysis.
+
+I also created [FYLARK](https://fylark.com), an accessible coding and AI-learning initiative for young people with dyslexia, and publish two newsletters: [Verimlilik Bülteni](https://suatatan.substack.com) in Turkish and [3000 Days](https://3000days.substack.com) in English.
+
+<div class="editorial-callout recruiter-callout">
+  <p class="case-kicker">FOR RECRUITERS & HIRING TEAMS</p>
+  <h2>Looking for a senior data scientist or applied-AI lead?</h2>
+  <p>I am open to conversations about senior and lead roles in data science, machine learning, applied AI and AI platforms—particularly work that combines technical leadership with production delivery.</p>
+  <div class="profile-actions">
+    <a class="button button-primary" href="mailto:suatatan+site@gmail.com?subject=Senior%20AI%20or%20Data%20role">Email Suat</a>
+    <a class="text-link" href="https://github.com/suatatan" target="_blank" rel="noopener">Review GitHub</a>
+  </div>
 </div>
 
 [Türkçe sürüm](/pages/2017-01-02-dr-suat-atan-kimdir.html)


### PR DESCRIPTION
## What changed

- cache-busts the shared stylesheet so About and Archive load the current responsive design immediately
- fixes the Dr. Suat Atan / PhD wordmark treatment and archive search hiding
- rebuilds English and Turkish About pages as recruiter-facing professional profiles
- adds current positioning, measurable recent projects, technical focus, prior North American experience and direct hiring-team calls to action
- preserves the existing About URLs for use in cover letters

## Validation

- patch whitespace check passed
- CSS braces validated
- production GitHub Pages build will perform the final Jekyll validation