### PR TITLE
Add French homepage and correct LinkedIn profile links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,7 +46,7 @@ social:
   links:
     - https://twitter.com/suatatan
     - https://github.com/suatatan
-    - https://www.linkedin.com/in/suatatan
+    - https://www.linkedin.com/in/suat-atan/
 
 # Google Analytics (production için)
 google_analytics: "" # Analytics ID buraya eklenecek

--- a/_data/landing.yml
+++ b/_data/landing.yml
@@ -165,3 +165,85 @@ tr:
   archive_label: "Açık arşiv"
   archive_text: "2006’dan bugüne teknoloji, veri, öğrenme ve hayat üzerine notlar."
   archive_cta: "Arşivi keşfet"
+
+fr:
+  lang_name: Français
+  nav:
+    - label: Expertise
+      url: "#expertise"
+    - label: Réalisations
+      url: "#work"
+    - label: Projets
+      url: "#ventures"
+    - label: Publications
+      url: "#insights"
+    - label: À propos
+      url: "#about"
+  eyebrow: "INTELLIGENCE ARTIFICIELLE • SCIENCE DES DONNÉES • TRANSFORMATION DES ORGANISATIONS"
+  headline: "Je transforme des idées complexes en systèmes d’IA qui fonctionnent."
+  intro: "Avec plus de 15 ans d’expérience, je conçois des solutions RAG, NLP et data pour les organisations, et j’aide leurs équipes à les adopter avec confiance."
+  primary_cta: "Travaillons ensemble"
+  secondary_cta: "Découvrir mes réalisations"
+  credibility: "Des solutions orientées production pour des banques, institutions publiques, universités et entreprises du secteur énergétique"
+  work_title: "Réalisations sélectionnées"
+  work:
+    - icon: forum
+      title: "Assistant RAG d’entreprise"
+      description: "Un assistant sécurisé et connecté aux documents internes pour retrouver et exploiter les connaissances de l’organisation."
+      detail: "Architecture, stratégie de recherche, évaluation et déploiement pour un accès fiable aux connaissances de l’entreprise."
+    - icon: school
+      title: "Formation Gemini & RAG"
+      description: "Une formation pratique qui permet aux équipes de passer des concepts d’IA générative à des applications fonctionnelles."
+      detail: "Ateliers fondés sur des cas réels : conception RAG, développement d’applications et adoption responsable."
+    - icon: monitoring
+      title: "Prévision de la demande énergétique"
+      description: "Des modèles de séries temporelles et de machine learning au service de la planification et des décisions opérationnelles."
+      detail: "De la qualité des données aux prévisions explicables et directement exploitables par les décideurs."
+  expertise_title: "De la stratégie à la production"
+  expertise_intro: "J’interviens à la rencontre de la profondeur technique, des réalités organisationnelles et d’une mise en œuvre mesurable."
+  expertise:
+    - title: "IA d’entreprise & RAG"
+      text: "Recherche d’information, recherche sémantique, intelligence documentaire et assistants d’IA prêts pour la production."
+    - title: "Systèmes data & NLP"
+      text: "Analyse de textes, prévision et produits data conçus autour de décisions opérationnelles concrètes."
+    - title: "Formation appliquée à l’IA"
+      text: "Des programmes pratiques pour développer les compétences IA des équipes techniques et métier."
+  ventures_label: "PRODUITS & INITIATIVES"
+  ventures_title: "Apprendre, construire et explorer"
+  ventures:
+    - icon: child_care
+      title: "FYLARK"
+      text: "Un programme technologique accessible où les enfants aux profils d’apprentissage différents découvrent le code et l’intelligence artificielle par petites étapes visuelles."
+      cta: "Découvrir FYLARK"
+      url: "https://fylark.com"
+    - icon: play_circle
+      title: "Cours Udemy"
+      text: "Des formations pratiques et accessibles qui transforment l’expérience en science des données et en IA en compétences utiles."
+      cta: "Voir les cours"
+      url: "https://www.udemy.com/user/suat-atan/"
+    - icon: menu_book
+      title: "Livres"
+      text: "Des ouvrages publiés sur l’analyse de données avec R, Google App Engine et l’analyse des réseaux."
+      cta: "Découvrir les livres"
+      url: "/pages/books-en.html"
+  newsletter_label: "VERİMLİLİK BÜLTENİ"
+  newsletter_text: "Des essais en turc sur l’intelligence artificielle, l’apprentissage et la réflexion."
+  newsletter_cta: "Voir la newsletter"
+  newsletter_secondary_label: "3000 DAYS"
+  newsletter_secondary_text: "Des réflexions en anglais sur la méditation, l’attention et la vie intérieure."
+  newsletter_secondary_cta: "Lire 3000 Days"
+  podcast_label: "PODCAST VERİMLİLİK BÜLTENİ"
+  podcast_text: "Des conversations et essais audio en turc sur l’apprentissage, la technologie et le travail."
+  podcast_cta: "Écouter sur Spotify"
+  about_title: "Ingénieur, data scientist, formateur et auteur"
+  about_text: "Titulaire d’un doctorat consacré au text mining, j’ai ensuite mené des recherches postdoctorales en NLP. Dans les institutions publiques, les secteurs réglementés et les projets internationaux, j’ai conduit des initiatives d’IA, de data et de logiciel, de l’idée à la production."
+  about_link: "Voir mon profil professionnel (EN)"
+  company_label: "Prestations professionnelles"
+  company_text: "Les missions de conseil et de formation sont réalisées par Ontario Bilişim ve Danışmanlık Ltd. Şti., fondée par le Dr Suat Atan."
+  company_cta: "Visiter Ontario Cloud"
+  contact_title: "Vous avez une initiative d’IA à concrétiser ?"
+  contact_text: "Expliquez-moi ce que vous souhaitez construire, améliorer ou transmettre. Je vous proposerai une prochaine étape concrète."
+  contact_cta: "Démarrer une conversation"
+  archive_label: "Archives ouvertes"
+  archive_text: "Des notes sur la technologie, la data, l’apprentissage et la vie depuis 2006."
+  archive_cta: "Explorer les archives"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -124,7 +124,7 @@
       "sameAs": [
         "https://twitter.com/suatatan",
         "https://github.com/suatatan",
-        "https://www.linkedin.com/in/suatatan"
+        "https://www.linkedin.com/in/suat-atan/"
       ]
     },
     {% if page.layout == 'post' %}

--- a/_layouts/editorial.html
+++ b/_layouts/editorial.html
@@ -38,7 +38,7 @@
 
     <footer class="site-footer section-shell">
       <p>© {{ site.time | date: '%Y' }} Dr. Suat Atan</p>
-      <div><a href="https://ontariocloud.com" target="_blank" rel="noopener">Ontario Cloud</a><a href="https://www.linkedin.com/in/suatatan" target="_blank" rel="me noopener">Suat Atan · LinkedIn</a><a href="mailto:suatatan+site@gmail.com">Email</a></div>
+      <div><a href="https://ontariocloud.com" target="_blank" rel="noopener">Ontario Cloud</a><a href="https://www.linkedin.com/in/suat-atan/" target="_blank" rel="me noopener">Suat Atan · LinkedIn</a><a href="mailto:suatatan+site@gmail.com">Email</a></div>
     </footer>
   </body>
 </html>

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -11,6 +11,7 @@
     <link rel="canonical" href="{{ site.url }}{{ page.url }}">
     <link rel="alternate" hreflang="en" href="{{ site.url }}/">
     <link rel="alternate" hreflang="tr" href="{{ site.url }}/tr/">
+    <link rel="alternate" hreflang="fr" href="{{ site.url }}/fr/">
     <link rel="alternate" hreflang="x-default" href="{{ site.url }}/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="{{ page.title }}">
@@ -21,7 +22,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ '/css/landing.css' | relative_url }}?v=20260816-4">
+    <link rel="stylesheet" href="{{ '/css/landing.css' | relative_url }}?v=20260816-5">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ '/images/icons/png/icon-32x32.png' | relative_url }}">
     <script type="application/ld+json">
       {
@@ -36,7 +37,7 @@
           "url": "https://ontariocloud.com"
         },
         "sameAs": [
-          "https://www.linkedin.com/in/suatatan",
+          "https://www.linkedin.com/in/suat-atan/",
           "https://github.com/suatatan",
           "https://suatatan.substack.com"
         ]
@@ -44,16 +45,20 @@
     </script>
   </head>
   <body class="landing-body">
-    <a class="skip-link" href="#main">Skip to content</a>
+    <a class="skip-link" href="#main">{% if page.lang == 'tr' %}İçeriğe geç{% elsif page.lang == 'fr' %}Aller au contenu{% else %}Skip to content{% endif %}</a>
     <header class="site-header" data-header>
-      <a class="wordmark" href="{% if page.lang == 'tr' %}/tr/{% else %}/{% endif %}" aria-label="Dr. Suat Atan home"><span>Dr. Suat Atan</span><small>PhD</small></a>
+      <a class="wordmark" href="{% if page.lang == 'tr' %}/tr/{% elsif page.lang == 'fr' %}/fr/{% else %}/{% endif %}" aria-label="Dr. Suat Atan home"><span>Dr. Suat Atan</span><small>PhD</small></a>
       <button class="menu-button" type="button" aria-expanded="false" aria-controls="site-nav" data-menu-button>
         <span class="material-symbols-rounded" aria-hidden="true">menu</span>
         <span class="sr-only">Menu</span>
       </button>
       <nav class="site-nav" id="site-nav" aria-label="Primary navigation" data-nav>
         {% for item in t.nav %}<a href="{{ item.url }}">{{ item.label }}</a>{% endfor %}
-        <a class="language-switch" href="{{ t.switch_url }}" hreflang="{% if page.lang == 'tr' %}en{% else %}tr{% endif %}">{{ t.switch_label }}</a>
+        <div class="language-menu" aria-label="Language">
+          <a href="/" hreflang="en"{% if page.lang == 'en' %} aria-current="page"{% endif %}>EN</a>
+          <a href="/tr/" hreflang="tr"{% if page.lang == 'tr' %} aria-current="page"{% endif %}>TR</a>
+          <a href="/fr/" hreflang="fr"{% if page.lang == 'fr' %} aria-current="page"{% endif %}>FR</a>
+        </div>
       </nav>
     </header>
 
@@ -169,14 +174,14 @@
       <section class="contact-section" id="contact" aria-labelledby="contact-title">
         <div class="section-shell contact-inner">
           <div><p class="eyebrow">CONTACT</p><h2 id="contact-title">{{ t.contact_title }}</h2><p>{{ t.contact_text }}</p></div>
-          <a class="button button-light" href="mailto:suatatan+site@gmail.com?subject={% if page.lang == 'tr' %}Danışmanlık görüşmesi{% else %}Consulting enquiry{% endif %}">{{ t.contact_cta }} <span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span></a>
+          <a class="button button-light" href="mailto:suatatan+site@gmail.com?subject={% if page.lang == 'tr' %}Danışmanlık görüşmesi{% elsif page.lang == 'fr' %}Projet IA / échange{% else %}Consulting enquiry{% endif %}">{{ t.contact_cta }} <span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span></a>
         </div>
       </section>
     </main>
 
     <footer class="site-footer section-shell">
       <p>© {{ site.time | date: '%Y' }} Suat Atan</p>
-      <div><a href="https://ontariocloud.com" target="_blank" rel="noopener">Ontario Cloud</a><a href="https://www.linkedin.com/in/suatatan" target="_blank" rel="me noopener">Suat Atan · LinkedIn</a><a href="https://github.com/suatatan" target="_blank" rel="noopener">GitHub</a></div>
+      <div><a href="https://ontariocloud.com" target="_blank" rel="noopener">Ontario Cloud</a><a href="https://www.linkedin.com/in/suat-atan/" target="_blank" rel="me noopener">Suat Atan · LinkedIn</a><a href="https://github.com/suatatan" target="_blank" rel="noopener">GitHub</a></div>
     </footer>
     <script src="{{ '/js/landing.js' | relative_url }}" defer></script>
   </body>

--- a/css/landing.css
+++ b/css/landing.css
@@ -46,9 +46,11 @@ button, a { -webkit-tap-highlight-color: transparent; }
 .wordmark small { padding: 3px 6px 2px; border: 1px solid rgba(7,88,217,.28); border-radius: 999px; color: var(--blue); font-size: 9px; font-weight: 800; line-height: 1; letter-spacing: .12em; text-transform: uppercase; }
 .site-nav { display: flex; align-items: center; gap: clamp(26px, 3.5vw, 58px); }
 .site-nav a { font-weight: 500; text-decoration: none; padding-block: 8px; position: relative; }
-.site-nav a:not(.language-switch)::after { content: ""; position: absolute; left: 0; right: 100%; bottom: 3px; height: 1px; background: var(--blue); transition: right .2s ease; }
-.site-nav a:hover::after, .site-nav a:focus-visible::after { right: 0; }
-.language-switch { color: var(--blue); font-weight: 700 !important; }
+.site-nav > a::after { content: ""; position: absolute; left: 0; right: 100%; bottom: 3px; height: 1px; background: var(--blue); transition: right .2s ease; }
+.site-nav > a:hover::after, .site-nav > a:focus-visible::after { right: 0; }
+.language-menu { display: flex; align-items: center; gap: 3px; padding-left: 10px; border-left: 1px solid var(--line); }
+.language-menu a { min-width: 31px; padding: 6px 7px; border-radius: 999px; color: var(--muted); font-size: 12px; font-weight: 800; text-align: center; }
+.language-menu a[aria-current="page"] { color: var(--blue); background: #edf4ff; }
 .menu-button { display: none; border: 0; background: transparent; color: var(--ink); padding: 8px; }
 
 .hero { min-height: 560px; display: grid; grid-template-columns: 62% 38%; align-items: center; margin-block: 26px; padding: 58px 5.2%; position: relative; overflow: hidden; border: 1px solid var(--line); background: linear-gradient(90deg, rgba(255,254,250,.99) 0%, rgba(255,254,250,.96) 48%, rgba(255,254,250,.48) 76%, rgba(255,254,250,.12) 100%), url('/images/hero-data-field.png') right center / auto 100% no-repeat; }
@@ -257,6 +259,8 @@ h1 { max-width: 740px; margin: 0; font-size: clamp(54px, 5vw, 78px); line-height
   .site-nav { position: fixed; inset: 68px 0 auto 0; padding: 20px 18px 26px; flex-direction: column; align-items: flex-start; gap: 10px; border-bottom: 1px solid var(--line); background: var(--paper); transform: translateY(-140%); transition: transform .25s ease; z-index: -1; }
   .site-nav.is-open { transform: translateY(0); }
   .site-nav a { width: 100%; padding: 10px 0; }
+  .language-menu { width: 100%; gap: 8px; padding: 12px 0 0; border-top: 1px solid var(--line); border-left: 0; }
+  .language-menu a { width: auto; padding: 7px 12px; }
   .hero { min-height: auto; margin-block: 14px; padding: 52px 26px 46px; background: linear-gradient(90deg, rgba(255,254,250,.98), rgba(255,254,250,.86)), url('/images/hero-data-field.png') center / cover no-repeat; }
   h1 { font-size: clamp(45px, 13vw, 64px); }
   .hero-intro { font-size: 17px; }

--- a/fr/index.md
+++ b/fr/index.md
@@ -1,0 +1,7 @@
+---
+layout: landing
+title: Dr Suat Atan — IA, RAG et solutions data
+description: Dr Suat Atan conçoit des systèmes d’intelligence artificielle, de RAG, de NLP et de données pour les organisations, et forme les équipes à leur mise en œuvre.
+lang: fr
+permalink: /fr/
+---

--- a/pages/2017-01-02-dr-suat-atan-kimdir.md
+++ b/pages/2017-01-02-dr-suat-atan-kimdir.md
@@ -11,7 +11,7 @@ eyebrow: PROFESYONEL PROFİL · KIDEMLİ VE LİDER POZİSYONLAR
 
 <div class="profile-actions">
   <a class="button button-primary" href="mailto:suatatan+site@gmail.com?subject=Kariyer%20fırsatı">İletişime geçin</a>
-  <a class="button button-secondary" href="https://www.linkedin.com/in/suatatan" target="_blank" rel="me noopener">LinkedIn profili</a>
+  <a class="button button-secondary" href="https://www.linkedin.com/in/suat-atan/" target="_blank" rel="me noopener">LinkedIn profili</a>
   <a class="button button-secondary" href="https://github.com/suatatan" target="_blank" rel="noopener">Kod arşivi</a>
 </div>
 

--- a/pages/about-en.md
+++ b/pages/about-en.md
@@ -11,7 +11,7 @@ eyebrow: PROFESSIONAL PROFILE · OPEN TO SENIOR & LEAD ROLES
 
 <div class="profile-actions">
   <a class="button button-primary" href="mailto:suatatan+site@gmail.com?subject=Career%20opportunity">Contact me</a>
-  <a class="button button-secondary" href="https://www.linkedin.com/in/suatatan" target="_blank" rel="me noopener">LinkedIn profile</a>
+  <a class="button button-secondary" href="https://www.linkedin.com/in/suat-atan/" target="_blank" rel="me noopener">LinkedIn profile</a>
   <a class="button button-secondary" href="https://github.com/suatatan" target="_blank" rel="noopener">Code archive</a>
 </div>
 


### PR DESCRIPTION
## Summary
- add a complete French homepage at `/fr/`
- replace the two-language toggle with an EN / TR / FR selector on desktop and mobile
- add French metadata, calls to action, portfolio, newsletter, podcast and company copy
- correct all profile links and structured-data references to `https://www.linkedin.com/in/suat-atan/`

## Validation
- parsed `_data/landing.yml` successfully for EN, TR and FR
- checked CSS brace balance
- ran `git diff --check`
- verified no old `linkedin.com/in/suatatan` profile URL remains in the edited source